### PR TITLE
Merged request

### DIFF
--- a/libsofia-sip-ua/nta/nta.c
+++ b/libsofia-sip-ua/nta/nta.c
@@ -6238,10 +6238,16 @@ static nta_incoming_t *incoming_find(nta_agent_t const *agent,
 
     /* RFC3261 - section 8.2.2.2 Merged Requests */
     if (return_merge) {
-      if (irq->irq_cseq->cs_method == cseq->cs_method &&
-	  strcmp(irq->irq_cseq->cs_method_name,
-		 cseq->cs_method_name) == 0)
-	*return_merge = irq, return_merge = NULL;
+      /* RFC3261 - section 17.2.3 Matching Requests to Server Transactions */
+      if (irq->irq_via->v_branch &&
+	  su_casematch(irq->irq_via->v_branch, v->v_branch) &&
+	  su_casematch(irq->irq_via->v_host, v->v_host) &&
+	  su_strmatch(irq->irq_via->v_port, v->v_port)) {
+        if (irq->irq_cseq->cs_method == cseq->cs_method &&
+	    strcmp(irq->irq_cseq->cs_method_name,
+		   cseq->cs_method_name) == 0)
+	  *return_merge = irq, return_merge = NULL;
+      }
     }
   }
 

--- a/libsofia-sip-ua/nta/nta.c
+++ b/libsofia-sip-ua/nta/nta.c
@@ -5120,7 +5120,7 @@ nta_leg_t *leg_find(nta_agent_t const *sa,
 
     if (leg_url && request_uri && url_cmp(leg_url, request_uri))
       continue;
-    if (leg_method && method_name && !su_casematch(method_name, leg_method))
+    if (leg_method == NULL || method_name && !su_casematch(method_name, leg_method))
       continue;
 
     /* Perfect match if both local and To have tag


### PR DESCRIPTION
This pull request consists of two commits and is aimed to avoid unexpected (wrong) "482 Request merged" responses. These commits are implementing missing matching rules described in RFC3261 sections 17.2.3.1/2, and also fixing leg matching condition. 

Use case: Call group calling process hunts sequentially for a group member that answers a group call. During a process it sends next INVITE upon previous one got canceled due to "No answer" or "Busy here" response. Such a next INVITE has  different branch id in topmost Via, however FreeSwitch (with mod_sofia module enabled) still qualifies this new transaction as to be merged with an existing one. So affords to add simple implementation of 17.2.3.1/2 rules and correcting the leg matching condition fixed the case.



